### PR TITLE
pass trough tox test command failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps=
     pytest-localserver
     pytest-cov
 commands =
-    - py.test {posargs: -v --cov taretto --cov-report term-missing}
+    py.test {posargs: -v --cov taretto --cov-report term-missing}
 
 [testenv:codechecks]
 skip_install = true


### PR DESCRIPTION
the dashes hides errors, fixes #11