### PR TITLE
Add widgetastic.patternfly5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
   widgetastic.core
   widgetastic.patternfly
   widgetastic.patternfly4
+  widgetastic.patternfly5
   navmazing
   sentaku
   apipkg


### PR DESCRIPTION
Hi

Adding widgetastic.patternfly5

While debugging converting my tests to patternfly5 I noticed

```
iqe_platform_ui/utils/mixins.py:class SearchableTableMixin(WTMixin):
and that module imports from taretto.ui.core import TextInput
```
my search for filter text input fails.
